### PR TITLE
rosetta_parser rewritten

### DIFF
--- a/rstoolbox/components/description.py
+++ b/rstoolbox/components/description.py
@@ -1,139 +1,140 @@
 import os
 import json
+import sys
 
 import numpy as np
 
+
 class Description( object ):
-    def __init__( self, ddict ):
-        self.keys    = {}
-        self.keysbr  = {}
-        self.perresi = []
-        self.namings = {}
-        self.ignores = []
-        self.chains  = []
-        self.labels  = []
-        self._auto   = False
-        self._process_description( self._file_vs_json( ddict ) )
 
-    def add_per_residues_keys( self, per_residues ):
-        self.perresi = per_residues
+    _PARAMS = [
+        "scores", "scores_ignore", "scores_rename", "scores_by_residue",
+        "naming", "sequence", "structure", "psipred", "labels"
+    ]
 
-    def fill_if_empty_scores( self, header ):
-        if self._auto:
-            for h in header:
-                if self.is_per_residue_key( h ):
-                    hh = self.get_per_residue_name( h )
-                    if not hh in self.keysbr and not hh in self.ignores:
-                        self.keysbr[hh]=hh
-                        continue
-                if not h in self.keys and not h in self.ignores:
-                    self.keys[h] = h
+    def __init__( self, **params ):
+        # Avoid false attributes and misspellings
+        for k in params:
+            if k not in self._PARAMS:
+                raise AttributeError("Wrong attribute provided. Accepted keys are: {}".format(",".join(self._PARAMS)))
 
-    def is_requested_key( self, key ):
-        return key in self.keys
+        # Load selections
+        self.scores            = params.get("scores",            "*" )
+        self.scores_ignore     = params.get("scores_ignore",     None)
+        self.scores_rename     = params.get("scores_rename",     None)
+        self.scores_by_residue = params.get("scores_by_residue", None)
+        self.naming            = params.get("naming",            None)
+        self.sequence          = params.get("sequence",          None)
+        self.structure         = params.get("structure",         None)
+        self.psipred           = params.get("psipred",           None)
+        self.labels            = params.get("labels",            None)
 
-    def is_per_residue_key( self, key ):
-        for k in self.perresi:
-            if key.startswith(k):
+        # Others
+        self._per_residues = ["residue_ddg_"]
+        self._scores       = {}
+
+        # Check that the "per_residue" scores requested are known.
+        if self.scores_by_residue is not None:
+            for k in self.scores_by_residue:
+                if k not in self._per_residues:
+                    raise AttributeError("Unknown per-residue score: {}".format(k))
+
+        if self.scores_ignore == "*":
+            self.scores = None
+
+        # Labels will be set in UPPERCASE
+        if self.labels is not None and self.labels != "*":
+            self.labels = [x.upper() for x in self.labels]
+
+    def wanted_score( self, score_name ):
+        for k in self._per_residues:
+            if score_name.startswith(k):
+                return False
+        if self.scores_ignore is not None:
+            if self.scores_ignore == "*" or score_name in self.scores_ignore:
+                return False
+        if self.scores_rename is not None:
+            if score_name in self.scores_rename:
                 return True
+        if self.scores == "*" or score_name in self.scores:
+            return True
         return False
 
-    def get_per_residue_name( self, key ):
-        for k in self.perresi:
-            if key.startswith(k):
-                return k
+    def score_name( self, score_name ):
+        if self.scores_rename is not None:
+            if score_name in self.scores_rename:
+                return self.scores_rename[score_name]
+        return score_name
 
-    def is_requested_per_residue_key( self, key ):
-        for k in self.keysbr:
-            if key.startswith(k):
+    def wanted_per_residue_score( self, score_name ):
+        if self.scores_by_residue is None:
+            return False
+        for k in self._per_residues:
+            if score_name.startswith(k):
                 return True
-        return False
 
-    def is_requested_label( self, label ):
-        return label.upper() in self.labels
-
-    def get_expected_per_residue_key( self, key ):
-        for k in self.keysbr:
-            if key.startswith(k):
-                return self.keysbr[k]
-        raise KeyError("Per residue key {} not found".format(key))
-
-    def get_expected_key( self, key ):
-        return self.keys[key]
+    def check_naming( self, header ):
+        if self.naming is None:
+            return
+        for h in self.naming:
+            if h in header and self.wanted_score(h):
+                if h == self.score_name(h):
+                    raise AttributeError("New column {} cannot be created, a score has that name".format(h))
 
     def get_naming_pairs( self, description ):
-        if len(self.namings) > 0:
+        if self.naming is not None:
             d = description.split("_")
-            c = 0
             for cn, n in enumerate(d):
-                if cn in self.namings:
-                    c += 1
-                    yield self.namings[cn], n
-                if c == len(self.namings):
+                if cn == len(self.naming):
                     break
+                if self.naming[cn] != "":
+                    yield self.naming[cn], n
 
-    def get_expected_sequences( self, chainsdct ):
-        guide  = np.array(list(chainsdct["stc"]))
-        seq    = chainsdct["seq"]
-        for ch in self.chains:
-            if ch in chainsdct["id"]:
-                guidep = np.where(guide == ch)[0]
-                yield "sequence_" + ch, seq[guidep[0]:guidep[-1] + 1]
-
-    def _file_vs_json( self, data ):
-        if isinstance( data, str ):
-            if not os.path.isfile( data ):
-                raise IOError("{0}: file not found.".format(data))
-            fd = gzip.open( data ) if data.endswith(".gz") else open( data )
-            text = "".join([x.strip() for x in fd])
-            data = json.loads(text)
+    def setup_labels( self, data ):
+        if self.labels is not None:
+            for l in self.labels:
+                data.setdefault(l.upper(), []).append("0")
         return data
 
-    def _process_description( self, ddict ):
-        # Option 0: cover no definition: Then, all scores get picked.
-        if ddict is None:
-            self._auto = True
-            return
-        # Option 1: scores is a list of scores to keep with the same name
-        # Thus, it can have a list or "*" if all scores are meant to be kept.
-        # Alternatively, one can pick only scores to ignore with scores_ignore.
-        # Both options have to be incompatible.
-        if "scores" in ddict:
-            if isinstance(ddict["scores"], list):
-                for sc in ddict["scores"]:
-                    self.keys[sc] = sc
-            else:
-                if ddict["scores"] == "*":
-                    self._auto = True
-        elif "scores_ignore" in ddict:
-            self.ignores = ddict["scores_ignore"]
-            self._auto = True
-        if "scores_ignore" in ddict:
-            self.ignores = ddict["scores_ignore"]
-        # Option 2: scores_rename is a list of scores to keep with a different name
-        if "scores_rename" in ddict:
-            for sc in ddict["scores_rename"]:
-                self.keys[sc] = ddict["scores_rename"][sc]
-        # Option 3: scores_by_residue is the prefix of a score that has to be saved
-        # by residue.
-        if "scores_by_residue" in ddict:
-            for sc in ddict["scores_by_residue"]:
-                sk = ddict["scores_by_residue"][sc]
-                if self.is_requested_key( sk ):
-                    raise KeyError( "The per residue score {} already exists as a score column".format(sk))
-                self.keysbr[sc] = sk
-        # naming splits the definition by "_" and sets the names as new columns
-        if "naming" in ddict:
-            for cname, name in enumerate(ddict["naming"]):
-                if name != "":
-                    if self.is_requested_key( name ):
-                        raise KeyError( "The naming split {} already exists as a score column".format(name))
-                    self.namings[cname] = name
-        # sequence define which sequence(s) the user wants to keep
-        if "sequence" in ddict:
-            self.chains = ddict["sequence"]
-        # labels selects from the REMARK LABELS line which are of interest
-        if "labels" in ddict:
-            self.labels = [x.upper() for x in ddict["labels"]]
-        if "split" in ddict:
-            pass
+    def get_expected_sequences( self, chains ):
+        if self.sequence is not None:
+            sele = set(chains["id"]) if self.sequence == "*" else set(self.sequence)
+            seq  = chains["seq"]
+            if len(sele.difference(chains["id"])) > 0:
+                raise ValueError("Requested a chain not present in the file. "
+                "Available chain are {}".format(",".join(list(set(chains["id"])))))
+            guide  = np.array(list(chains["id"]))
+            for ch in sele:
+                guidep = np.where(guide == ch)[0]
+                yield "sequence_" + ch, "".join(seq[guidep[0]:guidep[-1] + 1])
+
+    def get_expected_structures( self, chains ):
+        if self.structure is not None:
+            sele = set(chains["id"]) if self.structure == "*" else set(self.structure)
+            seq  = chains["dssp"]
+            if len(sele.difference(chains["id"])) > 0:
+                raise ValueError("Requested a chain not present in the file. "
+                "Available chain are {}".format(",".join(list(set(chains["id"])))))
+            guide  = np.array(list(chains["id"]))
+            for ch in sele:
+                guidep = np.where(guide == ch)[0]
+                yield "structure_" + ch, "".join(seq[guidep[0]:guidep[-1] + 1])
+
+    def get_expected_psipred( self, chains ):
+        if self.psipred is not None:
+            sele = set(chains["id"]) if self.psipred == "*" else set(self.psipred)
+            seq  = chains["psipred"]
+            if len(sele.difference(chains["id"])) > 0:
+                raise ValueError("Requested a chain not present in the file. "
+                "Available chain are {}".format(",".join(list(set(chains["id"])))))
+            guide  = np.array(list(chains["id"]))
+            for ch in sele:
+                guidep = np.where(guide == ch)[0]
+                yield "psipred_" + ch, "".join(seq[guidep[0]:guidep[-1] + 1])
+
+    def to_json( self ):
+        data = {}
+        for a in self._PARAMS:
+            if getattr(self, a) is not None:
+                data[a] = getattr(self, a)
+        return data

--- a/rstoolbox/io/__init__.py
+++ b/rstoolbox/io/__init__.py
@@ -1,5 +1,6 @@
 from .rosetta import open_rosetta_file, parse_rosetta_file
 from .rosetta import parse_rosetta_fragments
+from .rosetta import get_sequence_and_structure
 from .rosetta import make_structures
 from .sequence import read_fasta, write_fasta
 from .pymol   import pymol_mutant_selector


### PR DESCRIPTION
Now is easier to follow, can manage weird resnum lines that can appear
in regular PDBs, and parses DSSP and PSIPRED data (if present) in the
silent file.
A new function allows to automatically run a RosettaJob that will provide the DSSP values. Depends on having a distribution of Rosetta in which WriteSSEMover is implemented.