### PR TITLE
Label sequence

### DIFF
--- a/rstoolbox/analysis/sequence.py
+++ b/rstoolbox/analysis/sequence.py
@@ -680,7 +680,7 @@ def label_sequence( df, seqID, label ):
         sele = df.get_label(label.upper(), seqID)
         seq = df.get_sequence(seqID)
         return df.append(pd.Series(''.join(operator.itemgetter(
-                         *np.array([*sele]) - 1 )(list(seq))), [colname]))
+                         *np.array(sele) - 1 )(list(seq))), [colname]))
     else:
         raise NotImplementedError
 

--- a/rstoolbox/analysis/sequence.py
+++ b/rstoolbox/analysis/sequence.py
@@ -680,7 +680,7 @@ def label_sequence( df, seqID, label ):
         sele = df.get_label(label.upper(), seqID)
         seq = df.get_sequence(seqID)
         return df.append(pd.Series(''.join(operator.itemgetter(
-                         *np.array([*sele]) -1 )(list(seq))), [colname]))
+                         *np.array([*sele]) - 1 )(list(seq))), [colname]))
     else:
         raise NotImplementedError
 

--- a/rstoolbox/analysis/sequence.py
+++ b/rstoolbox/analysis/sequence.py
@@ -659,14 +659,14 @@ def label_sequence( df, seqID, label ):
     .. ipython::
 
         In [1]: from rstoolbox.io import parse_rosetta_file
-           ...: from rstoolbox.analysis import label_percentage
+           ...: from rstoolbox.analysis import label_sequence
            ...: import pandas as pd
            ...: pd.set_option('display.width', 1000)
            ...: pd.set_option('display.max_columns', 500)
            ...: df = parse_rosetta_file("../rstoolbox/tests/data/input_2seq.minisilent.gz",
            ...:                         {'scores': ['score'], 'sequence': '*',
            ...:                          'labels': ['MOTIF']})
-           ...: df = label_percentage(df, 'B', 'MOTIF')
+           ...: df = label_sequence(df, 'B', 'MOTIF')
            ...: df.head()
     """
     from rstoolbox.components import DesignFrame, DesignSeries

--- a/rstoolbox/analysis/sequence.py
+++ b/rstoolbox/analysis/sequence.py
@@ -679,7 +679,8 @@ def label_sequence( df, seqID, label ):
     elif isinstance(df, DesignSeries):
         sele = df.get_label(label.upper(), seqID)
         seq = df.get_sequence(seqID)
-        return df.append(pd.Series(''.join(operator.itemgetter(*np.array([*sele])-1)(list(seq))), [colname]))
+        return df.append(pd.Series(''.join(operator.itemgetter(
+                         *np.array([*sele]) -1 )(list(seq))), [colname]))
     else:
         raise NotImplementedError
 

--- a/rstoolbox/analysis/sequence.py
+++ b/rstoolbox/analysis/sequence.py
@@ -677,10 +677,10 @@ def label_sequence( df, seqID, label ):
                        axis=1, result_type='expand')
         return df2
     elif isinstance(df, DesignSeries):
-        sele = df.get_label(label.upper(), seqID)
+        sele = list(np.array(df.get_label(label.upper(), seqID).to_list()) - 1)  # Correct str count
         seq = df.get_sequence(seqID)
         return df.append(pd.Series(''.join(operator.itemgetter(
-                         *np.array(sele) - 1 )(list(seq))), [colname]))
+                         *sele)(list(seq))), [colname]))
     else:
         raise NotImplementedError
 

--- a/rstoolbox/tests/components/test_design.py
+++ b/rstoolbox/tests/components/test_design.py
@@ -241,6 +241,13 @@ class TestDesign( object ):
         assert len(df['CONTACT_B_perc'].unique()) > 1
         assert df['CONTACT_B_perc'].mean() == pytest.approx(0.4669, rel=1e-3)
 
+    def test_label_sequence(self):
+        sc_des  = {'scores': ['score'], 'sequence': '*', 'labels': ['MOTIF']}
+        df = ri.parse_rosetta_file(self.silent1, sc_des)
+        df = label_sequence(df, 'B', 'MOTIF')
+        assert df.iloc[0]['MOTIF_B_seq'] == 'DMLPERMIAAALRAIGEIFNAE'
+        assert df.iloc[5]['MOTIF_B_seq'] == 'DMQPEWAIAAALRAIGEIFNQW'
+
     def test_getseqs(self):
         sc_des  = {"sequence": "B"}
 

--- a/rstoolbox/tests/components/test_design.py
+++ b/rstoolbox/tests/components/test_design.py
@@ -244,7 +244,7 @@ class TestDesign( object ):
     def test_label_sequence(self):
         sc_des  = {'scores': ['score'], 'sequence': '*', 'labels': ['MOTIF']}
         df = ri.parse_rosetta_file(self.silent1, sc_des)
-        df = label_sequence(df, 'B', 'MOTIF')
+        df = ra.label_sequence(df, 'B', 'MOTIF')
         assert df.iloc[0]['MOTIF_B_seq'] == 'DMLPERMIAAALRAIGEIFNAE'
         assert df.iloc[5]['MOTIF_B_seq'] == 'DMQPEWAIAAALRAIGEIFNQW'
 

--- a/sphinx-docs/source/api.rst
+++ b/sphinx-docs/source/api.rst
@@ -88,6 +88,7 @@ Helper functions for sequence analysis. They can be called through ``rstoolbox.a
    ~analysis.secondary_structure_percentage
    ~analysis.selector_percentage
    ~analysis.label_percentage
+   ~analysis.label_sequence
    ~analysis.cumulative
 
 Plot

--- a/sphinx-docs/source/releases/V1.0.0.txt
+++ b/sphinx-docs/source/releases/V1.0.0.txt
@@ -4,3 +4,4 @@ v1.0.0 (xxx 2019)
 #. Added renumber, order, top_position cut and sampling to FragmentFrame
 #. Added the ability to attach a source column to FragmentFrame.
 #. Adds write new Rosetta fragment format strictly from the fragment data.
+#. Adds function to get the sequence given certain residue labels.


### PR DESCRIPTION
# Changes Proposed in this Pull Request:
- Added label_sequence function that takes in a DesignFrame, a chain identifier and a residue label and returns the sequence bit corresponding to the residue labels.

# Check List:
- [ ] whatsnew entry
- [ ] test function
- [ ] documentation updated (not recompiled)
