### PR TITLE
secondary_structure_percentage adaptation to pandas 1

### DIFF
--- a/rstoolbox/analysis/structure.py
+++ b/rstoolbox/analysis/structure.py
@@ -245,8 +245,10 @@ def secondary_structure_percentage( df, seqID, key_residues=None ):
     elif isinstance(df, DesignSeries):
         sse = list(df.get_structure(seqID, key_residues))
         csse = collections.Counter(sse)
-        dfp = df.append(pd.Series([float(csse['H']) / len(sse), float(csse['E']) / len(sse),
-                        float(csse['L']) / len(sse)], [H, E, L]))
+        dfp = copy.deepcopy(df)
+        dfp[H] = float(csse['H']) / len(sse)
+        dfp[E] = float(csse['E']) / len(sse)
+        dfp[L] = float(csse['L']) / len(sse)
         dfp.transfer_reference(df)
         return dfp
     else:

--- a/rstoolbox/analysis/structure.py
+++ b/rstoolbox/analysis/structure.py
@@ -13,6 +13,7 @@
 
 # Standard Libraries
 import collections
+import copy
 
 # External Libraries
 import pandas as pd


### PR DESCRIPTION
# Changes Proposed in this Pull Request:
- Avoid calling the pd.concat function when computing secondary structure percentages, which produces an `AttributeError` in pandas-1.1.0

# Check List:

- [X] closes #123 